### PR TITLE
Update cli.ts to work on more machines when called like `./cli.ts --args here`

### DIFF
--- a/cli.ts
+++ b/cli.ts
@@ -1,4 +1,4 @@
-#!/usr/bin/env npx ts-node
+#!/usr/bin/env -S npx ts-node
 import { decryptCli } from "./scripts/cli/decrypt.js";
 import { encryptCli } from "./scripts/cli/encrypt.js";
 import { exitWithError, parse, USAGE } from "./scripts/cli/parse.js";


### PR DESCRIPTION
<!-- prettier-ignore-start -->
## Description
It seems that shebang by default treats everything after a space as a single argument, so `npx` + `ts-node` is treated like looking for `npx ts-node` executable. `env` itself suggested me adding `-S` flag to fix it:
> dzek@dzek-Mint:/Projects/tmp/privacy-protect$ LC_ALL=C ./cli.ts encrypt -m "My secret" --hint "My hint" --deniableMessage "My deniable secret" ./out/secret.html
> /usr/bin/env: 'npx ts-node': No such file or directory
> /usr/bin/env: use -[v]S to pass options in shebang lines

This should make it work on more machines if it even works on some right now - I'm not sure about this. However on Ubuntu 22.04 this is required to make it work. The `-S` flag was probably added around 2017. I suspect if that's a conflict we should prefer newer systems.

## Test plan
1. Clone repo
2. Run `npm install`
3. Run `./cli.ts encrypt -m "My secret" --hint "My hint" ./secret.html`

## Possible regressions or performance implications
If `-S` flag is unknown to some old Linux distributions it may introduce a regression. I have no idea about version usage of Unix-like operating systems, but I believe everything that doesn't support this flag is pretty low on usage and we should prefer newest ones anyway. 

## Dependencies
none

## Reviewer checklist
<!-- See https://github.com/google/eng-practices/blob/master/review/reviewer/looking-for.md -->

- [X] Code is well-designed and only as complicated as necessary.
- [X] Good experience for clients of code.
- [X] Existing use-cases are implemented, not potential future ones (YAGNI).
- [X] Clear and consistent naming.
- [X] Comments and documentation are clear, useful, and explain why instead of what.
- [X] Sensible and attractive UI changes, if any.

<!-- prettier-ignore-end -->
