### PR TITLE
Replace backticks with double JSON.stringify().

### DIFF
--- a/src/lib/template-secret.ts
+++ b/src/lib/template-secret.ts
@@ -49,7 +49,7 @@ export function templateSecret(req: TemplateSecretReq): string {
 (() => {`,
         ""
       )
-      .replace(`"{.CONFIG}"`, "`" + JSON.stringify(config) + "`")
+      .replace(`"{.CONFIG}"`, JSON.stringify(JSON.stringify(config)))
   );
 }
 


### PR DESCRIPTION
This fixes #69

Newlines don't get properly encoded. The result of JSON.stringify() is a string, but to embed that string inside an HTML page, it needs to be encoded a second time. Then the `\n` newlines get converted to `\\n` so that the `\` is preserved.

In my testing this works.

<!-- prettier-ignore-start -->
## Description
<!-- Implementation and architectural changes introduced. For examples, see https://github.com/google/eng-practices/blob/master/review/developer/cl-descriptions.md -->

## Test plan
<!-- How to test changes. -->

## Possible regressions or performance implications
<!-- Impacts on other features or performance. -->

## Dependencies
<!-- Links to dependent PRs or issues. -->

## Reviewer checklist
<!-- See https://github.com/google/eng-practices/blob/master/review/reviewer/looking-for.md -->

- [ ] Code is well-designed and only as complicated as necessary.
- [ ] Good experience for clients of code.
- [ ] Existing use-cases are implemented, not potential future ones (YAGNI).
- [ ] Clear and consistent naming.
- [ ] Comments and documentation are clear, useful, and explain why instead of what.
- [ ] Sensible and attractive UI changes, if any.

<!-- prettier-ignore-end -->
